### PR TITLE
CIVIIB-44: Add Cleanpager first patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Patches for CleanPager Module
+
+This repo includes patches for CleanPager Module that is used as part of our Compuclient Website flavour.

--- a/patch1.patch
+++ b/patch1.patch
@@ -1,0 +1,13 @@
+diff --git a/cleanpager.module b/cleanpager.module
+index 83cff30..4a3d420 100644
+--- a/cleanpager.module
++++ b/cleanpager.module
+@@ -338,7 +338,7 @@ function _cleanpager_is_array_theme($themes, $theme_key) {
+  */
+ function cleanpager_theme_registry_alter(&$theme_registry) {
+   // Kill the next/previous forum topic navigation links.
+-  if ($theme_registry['pager_link']['function']['theme_pager_link']) {
++  if ($theme_registry['pager_link']['function'] == 'theme_pager_link') {
+     $theme_registry['pager_link']['function'] = 'cleanpager_theme_pager_link';
+   }
+ }


### PR DESCRIPTION
## Overview

In my commit here: https://github.com/compucorp/compuclient/pull/305/commits/e26feaf67d2a8fc900759188a63d2a9d4bdd37f6

I've added a patch to Cleanpager module: https://www.drupal.org/project/cleanpager/ that make it work on PHP 8 sites. But when I applied it to Compuclient distribution for testing as part of our PHP 8 testing, I applied it manually instead of using the `make` command to regenerate the whole Compuclient  distribution to save time, but I did not notice that the patch is targeting the `dev` branch of Cleanpager module, not version 1.0 which is the one we are using in Compuclient, and thus running the  `make` command resulting in failure, because it cannot apply the patch given the lines are different between the dev version and version 1.0 of CleanPager module.

And given is what we tested as part of PHP 8 testing was version 1.0 of this module + the patch (that I applied manually), not the dev version which has more extra stuff, I am creating this repo to add the patch to it while ensuring it targets the relative lines in version 1.0, and I will end up using the link for this patch in Compuclient make file.